### PR TITLE
Fix creating redundant quotes for groups in js script

### DIFF
--- a/src/main/resources/static/js/main.js
+++ b/src/main/resources/static/js/main.js
@@ -18,6 +18,7 @@ function getEvent() {
     let timeEnd = document.getElementById("time-end").value;
     let groups = getCheckedCheckBoxes('groups[]');
 
+
     let xhr = new XMLHttpRequest();
     xhr.open("PUT", "http://localhost:8080/api/create_event", true);
 
@@ -47,7 +48,7 @@ function getCheckedCheckBoxes(name) {
     let checkboxesChecked = [];
     for (let index = 0; index < checkboxes.length; index++) {
         if (checkboxes[index].checked) {
-            checkboxesChecked.push('"' + checkboxes[index].value + '"');
+            checkboxesChecked.push(checkboxes[index].value);
         }
     }
     return checkboxesChecked;


### PR DESCRIPTION
* JSON.stringify() wraps each element by quotes, and backend gets json with group values with double quotes. Fixed

Signed-off-by: Kirill Batyshchev <k.batyshchev@innopolis.university>